### PR TITLE
Force software based aes_cbc decryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlc-decrypter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tobias Matt <t.matt81@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/Bubblepoint/dlc-decoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A decoder library for dlc files"
 error-chain = "0.11.0"
 base64 = "0.7.0"
 reqwest = "0.8.5"
-rust-crypto = { git = "https://github.com/niluxv/rust-crypto", branch = "stable_0.2" }
+rust-crypto = "0.2.36"
 regex = "0.2.2"
 openssl = "0.10.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ base64 = "0.7.0"
 reqwest = "0.8.5"
 rust-crypto = "0.2.36"
 regex = "0.2.2"
-openssl = "0.10.5"
 
 [lib]
 name = "dlc_decrypter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A decoder library for dlc files"
 error-chain = "0.11.0"
 base64 = "0.7.0"
 reqwest = "0.8.5"
-rust-crypto = "0.2"
+rust-crypto = { git = "https://github.com/niluxv/rust-crypto", branch = "stable_0.2" }
 regex = "0.2.2"
 openssl = "0.10.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.7.0"
 reqwest = "0.8.5"
 rust-crypto = "0.2"
 regex = "0.2.2"
+openssl = "0.10.5"
 
 [lib]
 name = "dlc_decrypter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "A decoder library for dlc files"
 [dependencies]
 error-chain = "0.11.0"
 base64 = "0.7.0"
-reqwest = "0.8.1"
+reqwest = "0.8.5"
 rust-crypto = "0.2"
 regex = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ description = "A decoder library for dlc files"
 
 [dependencies]
 error-chain = "0.11.0"
-base64 = "0.7.0"
+base64 = "0.9.0"
 reqwest = "0.8.5"
 rust-crypto = "0.2.36"
-regex = "0.2.2"
+regex = "0.2.10"
 
 [lib]
 name = "dlc_decrypter"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ extern crate reqwest;
 extern crate crypto;
 extern crate regex;
 extern crate base64;
+extern crate openssl;
 
 pub mod error;
 
@@ -198,7 +199,7 @@ impl DlcDecoder {
         return Ok(data);
     }
 
-    fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+    /*fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
         println!("Decrypt RAW data");
         // create decryptor and set keys & values
         let mut decryptor = aes::cbc_decryptor(
@@ -229,6 +230,30 @@ impl DlcDecoder {
             // add the encrypted data to the result
             result.extend_from_slice(writ_buffer.take_read_buffer().take_remaining());
         };
+
+        // remove tailing zeros
+        result.retain(|x| *x !=  0 as u8);
+
+        return Ok(result);
+    }*/
+
+    fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+        println!("Decrypt RAW data");
+
+        use openssl::symm::{encrypt, Cipher};
+
+        let cipher = Cipher::aes_128_cbc();
+        let ciphertext = encrypt(
+            cipher,
+            key,
+            Some(iv),
+            data).unwrap();
+
+
+        let mut result = Vec::new();
+
+        println!("Decrypt");
+        result.extend_from_slice(&ciphertext);
 
         // remove tailing zeros
         result.retain(|x| *x !=  0 as u8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,18 +233,22 @@ impl DlcDecoder {
 
     fn get_jd_decryption_key(&self, key: &[u8]) -> Result<Vec<u8>> {
         // build the request url
+        println!("format url");
         let url = format!("http://service.jdownloader.org/dlcrypt/service.php?srcType=dlc&destType={}&data={}", &self.jd_app_name, str::from_utf8(key)?);
 
+        println!("make http call");
         // build up the request
-        let client = Client::new();
-        let mut res = client.get(&url)
+        let mut res = Client::new().get(&url)
             .header(Connection::close())
             .header(UserAgent::new("Mozilla/5.3 (Windows; U; Windows NT 5.1; de; rv:1.8.1.6) Gecko/2232 Firefox/3.0.0.R"))
             .send()?;
+        println!("end http call");
 
         // read the response
         let mut key = Vec::new();
         res.read_to_end(&mut key)?;
+
+        println!("have length");
 
         // check if response is long enough
         if key.len() != 33 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ impl DlcDecoder {
         return Ok(data);
     }
 
-    /*fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+    fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
         println!("Decrypt RAW data");
         // create decryptor and set keys & values
         let mut decryptor = aes::cbc_decryptor(
@@ -235,9 +235,9 @@ impl DlcDecoder {
         result.retain(|x| *x !=  0 as u8);
 
         return Ok(result);
-    }*/
+    }
 
-    fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+    /*fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
         println!("Decrypt RAW data");
 
         use openssl::symm::{encrypt, Cipher};
@@ -259,7 +259,7 @@ impl DlcDecoder {
         result.retain(|x| *x !=  0 as u8);
 
         return Ok(result);
-    }
+    }*/
 
     fn get_jd_decryption_key(&self, key: &[u8]) -> Result<Vec<u8>> {
         // build the request url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,12 +157,15 @@ impl DlcDecoder {
     /// Decrypt the contet of a .dlc file.
     pub fn from_data(&self, data: &[u8]) -> Result<DlcPackage> {
         // decrypt the .dlc data
+        println!("Decrypt dlc");
         let data = self.decrypt_dlc(data)?;
 
         // parse the dlc header data
+        println!("Parse header");
         let mut dlc = self.parse_header(&data)?;
 
         // parse the dlc body
+        println!("Parse body");
         self.parse_body(&mut dlc, &data)?;
 
         Ok(dlc)
@@ -196,6 +199,7 @@ impl DlcDecoder {
     }
 
     fn decrypt_raw_data(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
+        println!("Decrypt RAW data");
         // create decryptor and set keys & values
         let mut decryptor = aes::cbc_decryptor(
             aes::KeySize::KeySize128,
@@ -210,6 +214,7 @@ impl DlcDecoder {
         let mut writ_buffer = buffer::RefWriteBuffer::new(&mut buffer);
         let mut result = Vec::new();
 
+        println!("Decrypt");
         loop {
             // decrypt the buffer
             if decryptor.decrypt(&mut read_buffer, &mut writ_buffer, true).is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,22 +238,17 @@ impl DlcDecoder {
     /// Download the decryption key for the .dlc container
     fn get_jd_decryption_key(&self, key: &[u8]) -> Result<Vec<u8>> {
         // build the request url
-        println!("format url");
         let url = format!("http://service.jdownloader.org/dlcrypt/service.php?srcType=dlc&destType={}&data={}", &self.jd_app_name, str::from_utf8(key)?);
 
-        println!("make http call");
         // build up the request
         let mut res = Client::new().get(&url)
             .header(Connection::close())
             .header(UserAgent::new("Mozilla/5.3 (Windows; U; Windows NT 5.1; de; rv:1.8.1.6) Gecko/2232 Firefox/3.0.0.R"))
             .send()?;
-        println!("end http call");
 
         // read the response
         let mut key = Vec::new();
         res.read_to_end(&mut key)?;
-
-        println!("have length");
 
         // check if response is long enough
         if key.len() != 33 {
@@ -351,17 +346,17 @@ fn aes_cbc_decryptor<X: PaddingProcessor + Send + 'static>(
         iv: &[u8],
         padding: X) -> Box<Decryptor + 'static> {
     match key_size {
-        KeySize128 => {
+        KeySize::KeySize128 => {
             let aes_dec = aessafe::AesSafe128Decryptor::new(key);
             let dec = Box::new(CbcDecryptor::new(aes_dec, padding, iv.to_vec()));
             dec as Box<Decryptor + 'static>
         }
-        KeySize192 => {
+        KeySize::KeySize192 => {
             let aes_dec = aessafe::AesSafe192Decryptor::new(key);
             let dec = Box::new(CbcDecryptor::new(aes_dec, padding, iv.to_vec()));
             dec as Box<Decryptor + 'static>
         }
-        KeySize256 => {
+        KeySize::KeySize256 => {
             let aes_dec = aessafe::AesSafe256Decryptor::new(key);
             let dec = Box::new(CbcDecryptor::new(aes_dec, padding, iv.to_vec()));
             dec as Box<Decryptor + 'static>


### PR DESCRIPTION
Hi Bubblepoint,

with this pull request I do the following changes to the code:
* Force always a software based encryption to avoid runtime errors
* Bump to version 0.2.0
* Fix some comments
* Update dependency crates

I hope you can merge this request and upload a new version to crates.io.
After this is done, my actual project [spe3d](https://github.com/Roba1993/SPE3D) can again use it.

Thanks,
Robert